### PR TITLE
support jdbc pushdown

### DIFF
--- a/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JDBCTable.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JDBCTable.scala
@@ -8,7 +8,7 @@ import org.apache.spark.sql.connector.catalog._
 import org.apache.spark.sql.connector.read.ScanBuilder
 import org.apache.spark.sql.connector.write.{LogicalWriteInfo, WriteBuilder}
 import org.apache.spark.sql.types.StructType
-import org.apache.spark.sql.util.CaseInsensitiveStringMap
+import org.apache.spark.sql.util.{CaseInsensitiveStringMap, Logging}
 import org.apache.sql.runner.container.ConfigContainer
 
 import scala.collection.JavaConverters._
@@ -24,7 +24,8 @@ import scala.collection.mutable
  */
 case class JDBCTable(ident: Identifier) extends Table
   with SupportsRead
-  with SupportsWrite {
+  with SupportsWrite
+  with Logging {
 
   import MyJDBCOptions._
 

--- a/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/MyJDBCOptions.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/MyJDBCOptions.scala
@@ -12,7 +12,7 @@ import org.apache.spark.sql.catalyst.util.CaseInsensitiveMap
  *
  *      Spark内置的JDBCOptions 不会序列化用户传入的自定义属性，所以直接自己干
  */
-class MyJDBCOptions(@transient override val parameters: CaseInsensitiveMap[String])
+case class MyJDBCOptions(@transient override val parameters: CaseInsensitiveMap[String])
   extends JDBCOptions(parameters) {
 
   import JDBCOptions._
@@ -31,6 +31,9 @@ class MyJDBCOptions(@transient override val parameters: CaseInsensitiveMap[Strin
       s"Option '$JDBC_QUERY_STRING' is not applicable while writing.")
 
   val uniqueKeys = parameters.getOrElse(MyJDBCOptions.JDBC_UNIQUE_KEYS, "")
+
+  var filterWhereClause = parameters.getOrElse(MyJDBCOptions.JDBC_FILTER_WHERE_CLAUSE, "")
+
 }
 
 object MyJDBCOptions {
@@ -62,5 +65,6 @@ object MyJDBCOptions {
   val JDBC_SESSION_INIT_STATEMENT = newOption("sessionInitStatement")
   val JDBC_PUSHDOWN_PREDICATE = newOption("pushDownPredicate")
   val JDBC_UNIQUE_KEYS = newOption("uniqueKeys")
+  val JDBC_FILTER_WHERE_CLAUSE = newOption("filterWhereClause")
 
 }

--- a/src/test/scala/org/apache/spark/sql/optimizer/ExternalTableRuleSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/optimizer/ExternalTableRuleSuite.scala
@@ -64,8 +64,10 @@ class ExternalTableRuleSuite extends QueryTest with SQLTestUtils with Matchers {
       val df = spark.sql(
         s"""SELECT id, name
            |FROM jdbc.mysql.stu
+           |where id < 10
            |""".stripMargin)
       df.rdd.partitions.length should equal(3)
+      df.explain()
       df.show()
     }
   }


### PR DESCRIPTION
增加JDBC查询下推。

使用样例:

```sql
create table if not exists tmp.res (row_count int);

!set tidb_tb_inspect.inspector_assistants.numPartitions = 2;
!set tidb_tb_inspect.inspector_assistants.partitionColumn = assistant_nick;
!set tidb_tb_inspect.inspector_message.numPartitions = 2;
!set tidb_tb_inspect.inspector_message.partitionColumn= uuid;

INSERT OVERWRITE TABLE tmp.res
SELECT count(1)
FROM jdbc.tidb_tb_inspect.inspector_assistants a
JOIN jdbc.tidb_tb_inspect.inspector_message b
ON b.dt = '2021-04-13'
AND a.assistant_nick = b.assistant_nick
WHERE a.type = 'DEDUCTION';
```

实现原理：
1. jdbc数据表会通过datasource v2进行注册为新的JDBCTable
2. spark 解析sql中的查询条件，在`V2ScanRelationPushDown` 优化器中会尝试将filter下推到所有relation对象的Table中
3. Table在进行数据库数据Scan的时候，将filter转换出来的查询条件下推到查询的query中


![image](https://user-images.githubusercontent.com/3626747/114652596-c2ecb200-9d18-11eb-85fe-7a90d218a49e.png)


查询日志:

Driver 端解析日志
```
2021-04-13 21:53:00,914 INFO org.apache.spark.sql.execution.datasources.v2.V2ScanRelationPushDown:
Pushing operators to tidb_tb_inspect.inspector_assistants
Pushed Filters:
Post-Scan Filters: (type#6 = DEDUCTION)
Output: store_id#3, seller_nick#4, assistant_nick#5, type#6, enable_realtime#7, created_at#8, updated_at#9

2021-04-13 21:53:00,936 INFO org.apache.spark.sql.execution.datasources.v2.V2ScanRelationPushDown:
Pushing operators to tidb_tb_inspect.inspector_message
Pushed Filters:
Post-Scan Filters: (dt#20 = 1618243200000000)
Output: uuid#10, message_id#11, session_id#12, time_in_ms#13L, store_id#14, assistant_nick#15, buyer_nick#16, direction#17, role#18, json_content#19, dt#20, batch_id#21L, created_at#22, updated_at#23
```

Executor端解析日志

```

2021-04-13 21:44:17,715 INFO org.apache.spark.sql.execution.datasources.jdbc.JDBCPartitionReader: Execute jdbc query: SELECT * FROM inspector_assistants WHERE (crc32(assistant_nick) % 2 = 0 or assistant_nick is null) AND (`type` = 'DEDUCTION')

2021-04-13 21:44:19,405 INFO org.apache.spark.sql.execution.datasources.jdbc.JDBCPartitionReader: closed connection
2021-04-13 21:44:19,519 INFO org.apache.spark.sql.execution.datasources.jdbc.JDBCPartitionReader: Execute jdbc query: SELECT * FROM inspector_message WHERE (crc32(uuid) % 10 = 5) AND (`dt` = '2021-04-13 00:00:00.0')

```
